### PR TITLE
Add myself and authors of original files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Now you will be prompted for any LUKS password, and decrypt_gnupg_sc is never in
 
 ## License
 GPG encrypted root volume
+Copyright (C) 2004-2005 Wesley W. Terpstra <terpstra@debian.org>
+Copyright (C) 2005-2006 Michael Gebetsroither <michael.geb@gmx.at>
+Copyright (C) 2006-2008 David Härdeman <david@hardeman.nu>
+Copyright (C) 2005-2008 Jonas Meurer <jonas@freesources.org>
+Copyright (C) 2009,2014 Peter Lebbing <peter@digitalbrains.com>
 Copyright (C) 2018 Erik Nellessen
 
 This program is free software; you can redistribute it and/or


### PR DESCRIPTION
I would have posted this as an amendment to #2 if I had known how to.

My initial version of this code was straightforwardly adapted from files in the cryptsetup package of Debian lenny (which was the stable Debian version back then). The [debian/copyright file](https://sources.debian.org/src/cryptsetup/2:1.0.6-7/debian/copyright/) lists four authors for the tree where the files were in (debian/*), so I added them. I don't think it's likely they all had their hand in these particular files, but this is the granularity that is available. I think they need to be mentioned to correctly license this.