### PR TITLE
Adapting script for multiple distro compatibility

### DIFF
--- a/cryptgnupg_sc
+++ b/cryptgnupg_sc
@@ -17,61 +17,61 @@ prereqs)
 esac
 
 . /usr/share/initramfs-tools/hook-functions
-
-# Hooks for loading Gnupg software and key into the initramfs
+. /lib/cryptsetup/functions
 
 # Check whether cryptroot hook has installed decrypt_gnupg_sc script
 if [ ! -x ${DESTDIR}/lib/cryptsetup/scripts/decrypt_gnupg_sc ] ; then
     exit 0
 fi
 
-# Install cryptroot key files into initramfs
-keys=$(sed 's/^\(.*,\|\)key=//; s/,.*//' ${DESTDIR}/conf/conf.d/cryptroot)
-
-if [ "${keys}" != "none" ]; then
-    if [ -z "${keys}" ]; then
-        echo "$0: Missing key files in ${DESTDIR}/conf/conf.d/cryptroot" >&2
-        cat ${DESTDIR}/conf/conf.d/cryptroot >&2
-        exit 1
+# Hooks for loading Gnupg software and key into the initramfs
+copy_keys() {
+    crypttab_parse_options
+    if [ "${CRYPTTAB_OPTION_keyscript-}" = "/lib/cryptsetup/scripts/decrypt_gnupg_sc" ]; then
+        if [ -f "$CRYPTTAB_KEY" ]; then
+            keydir=$(dirname ${CRYPTTAB_KEY})
+            copy_file keyfile "$CRYPTTAB_KEY"
+            copy_file pubring "${keydir}/pubring.gpg"
+            for private_key in ${keydir}/private-keys-v1.d/*; do
+                copy_file private_key "${private_key}"
+            done
+        else
+            cryptsetup_message "ERROR: Target $CRYPTTAB_NAME has a non-existing key file $CRYPTTAB_KEY"
+            RV=1
+        fi
     fi
-    for key in ${keys} ; do
-        keydir=$(dirname ${key})
-	echo "WARNING: GnuPG key $key is copied to initramfs" >&2
-	echo "WARNING: GnuPG secret keys in ${keydir}/private-keys-v1.d are copied" \
-             "to initramfs" >&2
-        if [ ! -d ${DESTDIR}/${keydir} ] ; then
-            mkdir -p ${DESTDIR}/${keydir}
-        fi
-        chmod 700 ${DESTDIR}/${keydir}
-        cp -p ${key} ${DESTDIR}/${key}
-        cp -p ${keydir}/pubring.kbx ${DESTDIR}/${keydir}
-        cp -p -r ${keydir}/private-keys-v1.d ${DESTDIR}/${keydir}
-        if [ -e ${keydir}/gpg.conf ] ; then
-            cp -p ${keydir}/gpg.conf ${DESTDIR}/${keydir}
-        fi
-    done
-fi
+}
+
+RV=0
+crypttab_foreach_entry copy_keys
+
+# Install directories needed by smartcard reading daemon, command, and
+# key-script
+mkdir -p -- "$DESTDIR/etc/opensc" "$DESTDIR/usr/lib/pcsc" "$DESTDIR/var/run" "$DESTDIR/tmp"
+
+# Install pcscd daemon, drivers, conf file, and include libgcc as well since
+# pcscd utilizes pthread_cancel
+copy_exec /usr/sbin/pcscd
+LIB_DIR="/lib/$(uname -m)-linux-gnu"
+find -L "$LIB_DIR" -maxdepth 1 \( -name 'libgcc_s.*' -o -name 'libusb-*.so*' \) -type f | while read so; do
+    copy_exec "$so"
+done
+
+USR_LIB_DIR="/usr/lib/$(uname -m)-linux-gnu"
+find -L "$USR_LIB_DIR" -maxdepth 1 \( -name 'libpcsclite.so*' \) -type f | while read so; do
+    copy_exec "$so"
+done
+
+cp -rt "$DESTDIR/usr/lib" /usr/lib/pcsc
+cp -t "$DESTDIR/etc" /etc/reader.conf 2>/dev/null || true
+cp -t "$DESTDIR/etc" /etc/libccid_Info.plist
+
+# Install common needed binaries
+copy_exec /usr/bin/dirname
 
 # Install gnupg software
-echo "WARNING: /usr/bin/gpg is copied to initramfs" >&2
 copy_exec /usr/bin/gpg
-echo "WARNING: /usr/bin/gpg-agent is copied to initramfs" >&2
 copy_exec /usr/bin/gpg-agent
-echo "WARNING: /usr/lib/gnupg/scdaemon is copied to initramfs" >&2
 copy_exec /usr/lib/gnupg/scdaemon
 
-# some more libs for pcscd
-# only needed for card readers, which are not supported by the gpg internal ccid
-copy_exec /usr/sbin/pcscd
-copy_exec /usr/lib/pcsc/drivers/serial/libccidtwin.so
-copy_exec /usr/lib/pcsc/drivers/ifd-ccid.bundle/Contents/Linux/libccid.so
-copy_exec /usr/lib/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist
-copy_exec /etc/libccid_Info.plist
-if uname -r | grep -q amd64; then
-        copy_exec /usr/lib/x86_64-linux-gnu/libpcsclite.so.1.0.0
-        copy_exec /lib/x86_64-linux-gnu/libgcc_s.so.1
-else
-        copy_exec /usr/lib/i386-linux-gnu/libpcsclite.so.1.0.0
-        copy_exec /lib/i386-linux-gnu/libgcc_s.so.1
-fi
-exit 0
+exit $RV

--- a/decrypt_gnupg_sc
+++ b/decrypt_gnupg_sc
@@ -1,15 +1,10 @@
 #!/bin/sh
 
-# quick hack for starting pcscd
-# only needed for card readers, which are not supported by the gpg internal ccid
-mkdir -p /var/run
-pcscd &
-
 decrypt_gpg () {
         echo "Performing GPG key decryption ..." >&2
         if ! /lib/cryptsetup/askpass \
-                "Enter smartcard PIN or passphrase for key $1: " | \
-                /usr/bin/gpg -q --batch --pinentry-mode loopback --homedir "$(dirname $1)" \
+                "Enter smartcard PIN: " | \
+                /usr/bin/gpg -q --batch --no-tty --pinentry-mode loopback --homedir "$(dirname $1)" \
                 --trustdb-name /dev/null --passphrase-fd 0 --decrypt $1; then
                 return 1
         fi


### PR DESCRIPTION
I have created this pull request to propose an improvement of the script to make it compatible across different distros. The final goal could be the creation of a ".deb" package.

I've made it just as starting point, do not accept the changes.

Current status:
- I have to insert my Yubikey 4 AFTER the system is booted to make it works (I don't know why).
- If I press Ctrl+Alt+1 at Smartcard PIN prompt, I can see several errors in Yubikey initialization. However, the decryption is successful, and the LUKS partition is unlocked.
- Tested on Ubuntu 18.10
- Need to do tests on Debian system
- I have encrypted my "cryptkey.gpg" file only with the asymmetric method, and I have removed the part of the question which ask for the static passphrase. Perhaps it can be made configurable.

Errors (I don't know if they are related to the hook script):
```
00000000 ifdhandler.c:150:CreateChannelByNameOrChannel() failed
00000040 readerfactory.c:1106:RFInitializeReader() Open Port 0x200000 Failed (usb:1050/0407:libudev:0:/dev/bus/usb/002/002)
00000005 readerfactory.c:376:RFAddReader() Yubico Yubikey 4 OTP+U2F+CCID init failed.
```

I'm not an expert, up to now, I really appreciate collaborations and corrections to the code.

Thank you for your scripts, I like this type of tool.